### PR TITLE
Add GitHub star and fork buttons to website

### DIFF
--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -9,7 +9,7 @@
 <section class="hero">
   <div class="hero-container">
       <div class="hero-content">
-          <div class="hero-title-content">
+          <div class="hero-title-content" style="display: flex; flex-direction: column;">
               <div class="hero-title">
                   {{ $title }}
                   <img class="hero-logo" src="{{ printf "/images/%s" $image | relURL }}" alt="{{ $title }} logo. {{ $navbarLogo.altText }}">
@@ -23,8 +23,9 @@
                   
                   <!-- GitHub Stars and Forks Buttons -->
                   <div style="margin: 20px 0; text-align: center;">
-                    <iframe src="https://ghbtns.com/github-btn.html?user=gambitproject&repo=gambit&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Stars"></iframe>
-                    <iframe src="https://ghbtns.com/github-btn.html?user=gambitproject&repo=gambit&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Forks"></iframe>
+                    <a class="github-button" href="https://github.com/gambitproject/gambit" data-icon="octicon-star" data-size="large" data-show-count="true" aria-label="Star gambitproject/gambit on GitHub">Star</a>
+                    <a class="github-button" href="https://github.com/gambitproject/gambit/fork" data-icon="octicon-repo-forked" data-size="large" data-show-count="true" aria-label="Fork gambitproject/gambit on GitHub">Fork</a>
+                    <script async defer src="https://buttons.github.io/buttons.js"></script>
                   </div>
                   
                   {{ if $buttonText }}

--- a/layouts/partials/hero.html
+++ b/layouts/partials/hero.html
@@ -1,0 +1,39 @@
+{{- $navbarLogo     := .Site.Params.navbarlogo }}
+{{- $hero           := .Site.Params.hero }}
+{{- $title          := index $hero "title" }}
+{{- $subtitle       := index $hero "subtitle" }}
+{{- $buttonText     := index $hero "buttontext" }}
+{{- $buttonLink     := index $hero "buttonlink" }}
+{{- $image          := index $hero "image" }}
+
+<section class="hero">
+  <div class="hero-container">
+      <div class="hero-content">
+          <div class="hero-title-content">
+              <div class="hero-title">
+                  {{ $title }}
+                  <img class="hero-logo" src="{{ printf "/images/%s" $image | relURL }}" alt="{{ $title }} logo. {{ $navbarLogo.altText }}">
+              </div>
+              <div class="flex-column">
+                  {{ with $subtitle }}
+                  <div class="hero-subtitle">
+                      {{ . }}
+                  </div>
+                  {{ end }}
+                  
+                  <!-- GitHub Stars and Forks Buttons -->
+                  <div style="margin: 20px 0; text-align: center;">
+                    <iframe src="https://ghbtns.com/github-btn.html?user=gambitproject&repo=gambit&type=star&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Stars"></iframe>
+                    <iframe src="https://ghbtns.com/github-btn.html?user=gambitproject&repo=gambit&type=fork&count=true&size=large" frameborder="0" scrolling="0" width="170" height="30" title="GitHub Forks"></iframe>
+                  </div>
+                  
+                  {{ if $buttonText }}
+                  <div class="hero-cta">
+                      <a href="{{ $buttonLink }}"><button class="cta-button">{{ $buttonText }}</button></a>
+                  </div>
+                  {{ end }}
+              </div>
+          </div>
+      </div>
+  </div>
+</section>


### PR DESCRIPTION
- Closes #9 
- Also rearranges the title section vertically

### Landing page now looks like:

<img width="1355" height="867" alt="Screenshot 2025-08-05 at 13 52 24" src="https://github.com/user-attachments/assets/a203fb61-4cf8-472e-841c-e7cd441576b3" />
