### PR TITLE
Add section with list of good first issues

### DIFF
--- a/content/gsoc_2026.md
+++ b/content/gsoc_2026.md
@@ -16,6 +16,13 @@ In your cover letter please include answers to the following questions:
 3. Please provide us with details of the times of day and days of the week you intend to work on the project, to help us in scheduling regular catch ups.
 4. Is there anything that you’ll be studying or working on whilst working alongside us?
 
+## Good first issues
+
+We suggest that prospective contributors check out some of the "Good first issues" across the Gambit project's GitHub repositiories, and consider making a small contribution as part of their application. Some issues you may wish to tackle include:
+
+- [DrawTree: Add different options for colouring game graphics by player](https://github.com/gambitproject/draw_tree/issues/14)
+- [DrawTree: Add generate_svg function](https://github.com/gambitproject/draw_tree/issues/40)
+
 ## Project Ideas
 
 Prospective contributors should read through the project ideas listed below before submitting an application, following the Contributor Guidance above.


### PR DESCRIPTION
@tturocy @rahulsavani This PR adds a section in the GSoC page with a list of suggested good first issues you can add to. Is this what you had in mind?